### PR TITLE
feat(auth): Align registration and profile API with frontend requirem…

### DIFF
--- a/src/main/java/com/igrowker/feature/parkify/features/auth/controller/AuthController.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/controller/AuthController.java
@@ -10,7 +10,6 @@ import com.igrowker.feature.parkify.features.auth.dto.response.RegisterResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.UserResponse;
 import com.igrowker.feature.parkify.features.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,7 +22,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 
@@ -102,7 +106,7 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
         final RegisterResponse response = authService.register(request);
-        final URI location = uriBuilderService.buildUserLocationUri(response.getToken());
+        final URI location = uriBuilderService.buildUserLocationUri(response.getId());
         return ResponseEntity.created(location)
                 .body(response);
     }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/dto/request/RegisterRequest.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/dto/request/RegisterRequest.java
@@ -8,8 +8,6 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "User registration request")
 public record RegisterRequest(
-//        @NotBlank(message = "Username cannot be blank")
-        @Schema(hidden = true)
         String username,
 
         @Schema(description = "User's email", example = "user@example.com")
@@ -17,17 +15,13 @@ public record RegisterRequest(
         @Email(message = "Invalid email format")
         String email,
 
-//        @NotBlank(message = "Password cannot be blank")
         @Schema(description = "User's password", example = "password123")
         @Size(min = 6, message = "Password must be at least 6 characters long")
         String password,
 
-//        @NotBlank(message = "Role cannot be blank")
-        @Schema(hidden = true)
         @Pattern(regexp = "^(DRIVER|OWNER)$", message = "Role must be either DRIVER or OWNER")
         String role,
 
-//        @NotBlank(message = "Contact phone cannot be blank")
-        @Schema(hidden = true)
-        String contactPhone) {
+        String contactPhone
+) {
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/dto/response/RegisterResponse.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/dto/response/RegisterResponse.java
@@ -2,12 +2,10 @@ package com.igrowker.feature.parkify.features.auth.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
 @Schema(description = "Response containing user registration details")
-@Data
 @AllArgsConstructor
-public class RegisterResponse {
-    @Schema(description = "JWT token", example = "eyJhbGciOiJIUzI1NiIsInR...")
-    private String token;
+@SuperBuilder
+public class RegisterResponse extends UserResponse {
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/dto/response/UserResponse.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/dto/response/UserResponse.java
@@ -1,18 +1,22 @@
 package com.igrowker.feature.parkify.features.auth.dto.response;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
 
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserResponse {
     private String id;
-    private String name;
+    private String username;
     private String email;
     private String role;
     private String contactPhone;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/entities/AuthUser.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/entities/AuthUser.java
@@ -10,9 +10,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -43,12 +49,10 @@ public class AuthUser {
     @ToString.Exclude
     private String password;
 
-//    @NotNull(message = "Role cannot be null")
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
 
-//    @NotBlank(message = "Contact phone cannot be blank")
     @Column(name = "contact_phone", nullable = false)
     private String contactPhone;
 
@@ -58,7 +62,12 @@ public class AuthUser {
     @Column(name = "longitude")
     private Double longitude;
 
-    @Column(name = "location_updated_at")
-    private LocalDateTime locationUpdatedAt;
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthServiceImpl.java
@@ -3,7 +3,6 @@ package com.igrowker.feature.parkify.features.auth.service;
 import com.igrowker.feature.parkify.exception.EmailAlreadyExistsException;
 import com.igrowker.feature.parkify.features.auth.dto.request.LoginRequest;
 import com.igrowker.feature.parkify.features.auth.dto.request.RegisterRequest;
-import com.igrowker.feature.parkify.features.auth.dto.request.UpdateEmailRequest;
 import com.igrowker.feature.parkify.features.auth.dto.response.LoginResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.RegisterResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.UserResponse;
@@ -14,14 +13,11 @@ import com.igrowker.feature.parkify.features.auth.security.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
@@ -50,31 +46,27 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public RegisterResponse register(RegisterRequest request) {
         if (authUserRepository.findByEmail(request.email()).isPresent()) {
-            throw new EmailAlreadyExistsException("El correo electrónico ya está registrado.");
+            throw new EmailAlreadyExistsException("This email already registered.");
         }
 
-        AuthUser newUser = new AuthUser();
+        final AuthUser newUser = AuthUser.builder()
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .role(request.role() != null ? Role.valueOf(request.role()) : Role.OWNER)
+                .username(request.username() != null ? request.username() : "")
+                .contactPhone(request.contactPhone() != null ? request.contactPhone() : "")
+                .build();
+        final AuthUser savedUser = authUserRepository.save(newUser);
 
-        newUser.setEmail(request.email());
-        newUser.setPassword(passwordEncoder.encode(request.password()));
-
-        newUser.setEmail(request.email());
-        newUser.setPassword(passwordEncoder.encode(request.password()));
-        newUser.setRole(Role.OWNER);
-        newUser.setUsername(request.username() != null ? request.username() : "Owner");
-        newUser.setContactPhone(request.contactPhone() != null ? request.contactPhone() : "");
-
-        authUserRepository.save(newUser);
-
-        UserDetails userDetails = new org.springframework.security.core.userdetails.User(
-                newUser.getEmail(),
-                newUser.getPassword(),
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + newUser.getRole().name()))
-        );
-
-        String token = jwtService.generateToken(userDetails);
-
-        return new RegisterResponse(token);
+        return RegisterResponse.builder()
+                .id(String.valueOf(savedUser.getId()))
+                .username(savedUser.getUsername())
+                .email(savedUser.getEmail())
+                .role(savedUser.getRole().name())
+                .contactPhone(savedUser.getContactPhone())
+                .createdAt(savedUser.getCreatedAt())
+                .updatedAt(savedUser.getUpdatedAt())
+                .build();
     }
 
     @Override
@@ -86,10 +78,12 @@ public class AuthServiceImpl implements AuthService {
                 );
         return UserResponse.builder()
                 .id(String.valueOf(authUser.getId()))
-                .name(authUser.getUsername())
+                .username(authUser.getUsername())
                 .email(authUser.getEmail())
                 .role(authUser.getRole().name())
                 .contactPhone(authUser.getContactPhone())
+                .createdAt(authUser.getCreatedAt())
+                .updatedAt(authUser.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/com/igrowker/feature/parkify/features/user/controller/UserController.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/user/controller/UserController.java
@@ -1,17 +1,14 @@
 package com.igrowker.feature.parkify.features.user.controller;
 
-import com.igrowker.feature.parkify.features.user.dto.request.LocationUpdateRequest;
 import com.igrowker.feature.parkify.features.user.dto.response.PublicUserResponse;
-import com.igrowker.feature.parkify.features.user.service.UserService; // Нужен сервис
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import com.igrowker.feature.parkify.features.user.service.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Users", description = "User-related operations")
 @RestController
@@ -20,25 +17,6 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
-
-    // #19
-    @Operation(
-            summary = "Update current user's location (DEPRECATED)",
-            description = "DEPRECATED: This endpoint is no longer recommended for use in the primary driver flow. Location is typically passed as query parameters in parking search requests.",
-            deprecated = true
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "Location updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request")
-    })
-    @PutMapping("/me/location")
-    @Deprecated(since = "2024-04-23", forRemoval = true)
-    public ResponseEntity<Void> updateMyLocation(
-            @Valid @RequestBody LocationUpdateRequest request, Authentication authentication
-    ) {
-        userService.updateUserLocation(authentication.getName(), request);
-        return ResponseEntity.noContent().build();
-    }
 
     // part of #16 and #23
     @GetMapping("/{userId}")

--- a/src/main/java/com/igrowker/feature/parkify/features/user/service/UserService.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/user/service/UserService.java
@@ -1,12 +1,8 @@
 package com.igrowker.feature.parkify.features.user.service;
 
-import com.igrowker.feature.parkify.features.user.dto.request.LocationUpdateRequest;
 import com.igrowker.feature.parkify.features.user.dto.response.PublicUserResponse;
-import jakarta.validation.Valid;
 
 public interface UserService {
-    @Deprecated(since = "2024-04-23", forRemoval = true)
-    void updateUserLocation(String name, @Valid LocationUpdateRequest request);
 
     PublicUserResponse getPublicUserById(String userId);
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/user/service/UserServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/user/service/UserServiceImpl.java
@@ -1,34 +1,12 @@
 package com.igrowker.feature.parkify.features.user.service;
 
-import com.igrowker.feature.parkify.features.auth.entities.AuthUser;
-import com.igrowker.feature.parkify.features.auth.repository.AuthUserRepository;
-import com.igrowker.feature.parkify.features.user.dto.request.LocationUpdateRequest;
 import com.igrowker.feature.parkify.features.user.dto.response.PublicUserResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
-    private final AuthUserRepository authUserRepository;
-    @Override
-    @Deprecated(since = "2024-04-23", forRemoval = true)
-    public void updateUserLocation(String email, LocationUpdateRequest request) {
-        log.info("Updating location for user: {}", email);
-        AuthUser user = authUserRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
-
-        user.setLatitude(request.latitude());
-        user.setLongitude(request.longitude());
-        user.setLocationUpdatedAt(LocalDateTime.now());
-
-        authUserRepository.save(user);
-    }
 
     @Override
     public PublicUserResponse getPublicUserById(String userId) {

--- a/src/test/java/com/igrowker/feature/parkify/features/auth/controller/AuthControllerIT.java
+++ b/src/test/java/com/igrowker/feature/parkify/features/auth/controller/AuthControllerIT.java
@@ -2,24 +2,35 @@ package com.igrowker.feature.parkify.features.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igrowker.feature.parkify.features.auth.dto.request.LoginRequest;
+import com.igrowker.feature.parkify.features.auth.dto.request.RegisterRequest;
+import com.igrowker.feature.parkify.features.auth.dto.response.LoginResponse;
+import com.igrowker.feature.parkify.features.auth.repository.AuthUserRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -30,25 +41,25 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "jwt.secret=TXlUZXN0U2VjcmV0S2V5VGhhdElzTG9uZ0Vub3VnaDEyMw==",
         "spring.jpa.hibernate.ddl-auto=create-drop"
 })
-@Sql(statements = {
-        "DELETE FROM users WHERE email = 'test.owner.it@example.com';",
-        "INSERT INTO users (username, email, password, role, contact_phone) " +
-                "VALUES ('testuser', 'test.owner.it@example.com', " +
-                "'$2a$10$PK8hd/HO2R/mvqqhdyhS7.QjRF5AKbCMeclnVm.yV6tchnT/CkN6K', " +
-                "'OWNER', " +
-                "'1234567890' );"
-})
 class AuthControllerIT {
 
     @Container
     static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>(
             DockerImageName.parse("postgres:15")
     );
+
     @Autowired
     private MockMvc mockMvc;
+
     @Autowired
     private ObjectMapper objectMapper;
-    private LoginRequest loginRequest;
+
+    @Autowired
+    private AuthUserRepository authUserRepository;
+
+    private LoginRequest loginRequestExistingUser;
+    private final String existingUserEmail = "test.owner.it@example.com";
+    private final String existingUserPassword = "password";
 
     @DynamicPropertySource
     static void dynamicProperties(DynamicPropertyRegistry registry) {
@@ -59,58 +70,199 @@ class AuthControllerIT {
 
     @BeforeEach
     void setUp() {
-        loginRequest = new LoginRequest("test.owner.it@example.com", "password");
+        loginRequestExistingUser = new LoginRequest(existingUserEmail, existingUserPassword);
+        authUserRepository.findByEmail("new.it.user@example.com").ifPresent(authUserRepository::delete);
+        authUserRepository.findByEmail("new.driver.it@example.com").ifPresent(authUserRepository::delete);
     }
 
-    @Test
-    void login_ValidCredentials_ShouldReturnOkAndToken() throws Exception {
-        mockMvc.perform(post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest)))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.token").isNotEmpty());
+    @AfterEach
+    void tearDown() {
+        authUserRepository.findByEmail("new.it.user@example.com").ifPresent(authUserRepository::delete);
+        authUserRepository.findByEmail("new.driver.it@example.com").ifPresent(authUserRepository::delete);
     }
 
-    @Test
-    void login_InvalidCredentials_ShouldReturnUnauthorized() throws Exception {
-        final LoginRequest loginRequest1 = new LoginRequest(loginRequest.email(), "wrongpassword");
+    @Nested
+    @DisplayName("Login Endpoint (/api/v1/auth/login)")
+    @Sql(statements = {
+            "DELETE FROM users WHERE email = 'test.owner.it@example.com';",
+            "INSERT INTO users (username, email, password, role, contact_phone, created_at, updated_at) " +
+                    "VALUES ('testuser', 'test.owner.it@example.com', " +
+                    "'$2a$10$PK8hd/HO2R/mvqqhdyhS7.QjRF5AKbCMeclnVm.yV6tchnT/CkN6K', " +
+                    "'OWNER', " +
+                    "'1234567890', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP );"
+    })
+    class LoginTests {
+        @Test
+        void login_ValidCredentials_ShouldReturnOkAndTokenAndEmail() throws Exception {
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(loginRequestExistingUser)))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.token").isNotEmpty())
+                    .andExpect(jsonPath("$.email", is(existingUserEmail)));
+        }
 
-        mockMvc.perform(post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest1)))
-                .andExpect(status().isUnauthorized());
+        @Test
+        void login_InvalidCredentials_ShouldReturnUnauthorized() throws Exception {
+            final LoginRequest invalidLogin = new LoginRequest(existingUserEmail, "wrongpassword");
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(invalidLogin)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void login_UserNotFound_ShouldReturnUnauthorized() throws Exception {
+            final LoginRequest nonExistentUserLogin = new LoginRequest("nonexistent.user@example.com", existingUserPassword);
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(nonExistentUserLogin)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void login_InvalidRequestBody_MissingEmail_ShouldReturnBadRequest() throws Exception {
+            final LoginRequest invalidRequest = new LoginRequest("", existingUserPassword);
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(invalidRequest)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void login_InvalidRequestBody_MissingPassword_ShouldReturnBadRequest() throws Exception {
+            final LoginRequest invalidRequest = new LoginRequest(existingUserEmail, "");
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(invalidRequest)))
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    void login_UserNotFound_ShouldReturnUnauthorized() throws Exception {
-        final LoginRequest loginRequest1 = new LoginRequest("nonexistent.user@example.com", loginRequest.password());
+    @Nested
+    @DisplayName("Register Endpoint (/api/v1/auth/register)")
+    class RegisterTests {
 
-        mockMvc.perform(post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest1)))
-                .andExpect(status().isUnauthorized());
+        private final String newUserEmail = "new.it.user@example.com";
+        private final String newUserPass = "password123";
+        private final String newUserName = "New IT User";
+        private final String newUserRole = "OWNER";
+        private final String newUserPhone = "9876543210";
+
+        @Test
+        void register_ValidRequest_ShouldReturnCreatedAndUserData() throws Exception {
+            RegisterRequest registerRequest = new RegisterRequest(
+                    newUserName, newUserEmail, newUserPass, newUserRole, newUserPhone
+            );
+
+            mockMvc.perform(post("/api/v1/auth/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(registerRequest)))
+                    .andExpect(status().isCreated())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(header().exists(HttpHeaders.LOCATION))
+                    .andExpect(jsonPath("$.id").isNotEmpty())
+                    .andExpect(jsonPath("$.username", is(newUserName)))
+                    .andExpect(jsonPath("$.email", is(newUserEmail)))
+                    .andExpect(jsonPath("$.role", is(newUserRole)))
+                    .andExpect(jsonPath("$.contactPhone", is(newUserPhone)))
+                    .andExpect(jsonPath("$.createdAt").isNotEmpty())
+                    .andExpect(jsonPath("$.updatedAt").isNotEmpty());
+        }
+
+        @Test
+        void register_EmailAlreadyExists_ShouldReturnBadRequest() throws Exception {
+            final RegisterRequest initialRegisterRequest = new RegisterRequest(
+                    "UserToConflict", newUserEmail, newUserPass, "DRIVER", "111222333"
+            );
+            mockMvc.perform(post("/api/v1/auth/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(initialRegisterRequest)))
+                    .andExpect(status().isCreated());
+
+            final RegisterRequest duplicateRegisterRequest = new RegisterRequest(
+                    "AnotherUser", newUserEmail, "anotherPass", "OWNER", "444555666"
+            );
+            mockMvc.perform(post("/api/v1/auth/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(duplicateRegisterRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message", is("This email already registered.")));
+        }
+
+        @Test
+        void register_InvalidRole_ShouldReturnBadRequest() throws Exception {
+            final RegisterRequest registerRequest = new RegisterRequest(
+                    newUserName, "invalid.role.user@example.com", newUserPass, "INVALID_ROLE", newUserPhone
+            );
+            mockMvc.perform(post("/api/v1/auth/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(registerRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.details.role", is("Role must be either DRIVER or OWNER")));
+        }
+
+        @Test
+        void register_ShortPassword_ShouldReturnBadRequest() throws Exception {
+            final RegisterRequest registerRequest = new RegisterRequest(
+                    newUserName, "short.pass.user@example.com", "123", newUserRole, newUserPhone
+            );
+
+            mockMvc.perform(post("/api/v1/auth/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(registerRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.details.password", is("Password must be at least 6 characters long")));
+        }
     }
 
+    @Nested
+    @DisplayName("Get Current User Endpoint (/api/v1/auth/me)")
+    @Sql(statements = {
+            "DELETE FROM users WHERE email = 'test.owner.it@example.com';",
+            "INSERT INTO users (id, username, email, password, role, contact_phone, created_at, updated_at) " +
+                    "VALUES (101, 'testuserForMe', 'test.owner.it@example.com', " +
+                    "'$2a$10$PK8hd/HO2R/mvqqhdyhS7.QjRF5AKbCMeclnVm.yV6tchnT/CkN6K', " +
+                    "'OWNER', " +
+                    "'1234567890', '2023-01-01T10:00:00', '2023-01-02T11:00:00' );"
+    })
+    class GetMeTests {
 
-    @Test
-    void login_InvalidRequestBody_MissingEmail_ShouldReturnBadRequest() throws Exception {
-        final LoginRequest invalidRequest = new LoginRequest("", "password");
+        private String authenticateAndGetToken(String email, String password) throws Exception {
+            final MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(new LoginRequest(email, password))))
+                    .andExpect(status().isOk())
+                    .andReturn();
+            final String responseString = result.getResponse().getContentAsString();
+            final LoginResponse loginResponse = objectMapper.readValue(responseString, LoginResponse.class);
+            return loginResponse.token();
+        }
 
-        mockMvc.perform(post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidRequest)))
-                .andExpect(status().isBadRequest());
+        @Test
+        void getCurrentUser_Authenticated_ShouldReturnUserData() throws Exception {
+            final String token = authenticateAndGetToken(existingUserEmail, existingUserPassword);
+
+            mockMvc.perform(get("/api/v1/auth/me")
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.id", is("101")))
+                    .andExpect(jsonPath("$.username", is("testuserForMe")))
+                    .andExpect(jsonPath("$.email", is(existingUserEmail)))
+                    .andExpect(jsonPath("$.role", is("OWNER")))
+                    .andExpect(jsonPath("$.contactPhone", is("1234567890")))
+                    .andExpect(jsonPath("$.createdAt", is("2023-01-01T10:00:00")))
+                    .andExpect(jsonPath("$.updatedAt", is("2023-01-02T11:00:00")));
+        }
+
+        @Test
+        void getCurrentUser_NotAuthenticated_ShouldReturnForbidden() throws Exception {
+            mockMvc.perform(get("/api/v1/auth/me")
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isForbidden());
+        }
     }
-
-    @Test
-    void login_InvalidRequestBody_MissingPassword_ShouldReturnBadRequest() throws Exception {
-        final LoginRequest invalidRequest = new LoginRequest("test.owner.it@example.com", "");
-
-        mockMvc.perform(post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidRequest)))
-                .andExpect(status().isBadRequest());
-    }
-
 }

--- a/src/test/java/com/igrowker/feature/parkify/features/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/igrowker/feature/parkify/features/auth/controller/AuthControllerTest.java
@@ -16,13 +16,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,24 +39,33 @@ class AuthControllerTest {
     private AuthController authController;
 
     private LoginRequest loginRequest;
-    private final String testToken = "mockJwtToken123";
     private final String testEmail = "test@example.com";
     private RegisterRequest registerRequest;
+    private final String expectedUserId = "12345";
+    private final String expectedUsername = "kris";
+    private final String expectedEmailForRegister = "kris@example.com";
+    private final String expectedRole = "OWNER";
+    private final String expectedPhone = "0123456789";
+    private final LocalDateTime mockCreatedAt = LocalDateTime.now().minusDays(1);
+    private final LocalDateTime mockUpdatedAt = LocalDateTime.now();
 
     @BeforeEach
     void setUp() {
         loginRequest = new LoginRequest(testEmail, "password");
-
         registerRequest = new RegisterRequest(
-                "kris", "kris@example.com", "Password",
-                "role", "0123456789"
-                );
+                expectedUsername,
+                expectedEmailForRegister,
+                "Password",
+                expectedRole,
+                expectedPhone
+        );
     }
 
     @Test
     void login_Success_ShouldReturnOkWithToken() {
+        String localTestToken = "mockJwtToken123";
         when(authService.login(any(LoginRequest.class)))
-                .thenReturn(new LoginResponse(testToken, testEmail));
+                .thenReturn(new LoginResponse(localTestToken, testEmail));
 
         final ResponseEntity<LoginResponse> response = authController.login(loginRequest);
 
@@ -64,7 +73,8 @@ class AuthControllerTest {
                 () -> assertNotNull(response),
                 () -> assertEquals(HttpStatus.OK, response.getStatusCode()),
                 () -> assertNotNull(response.getBody()),
-                () -> assertEquals(testToken, response.getBody().token())
+                () -> assertEquals(localTestToken, response.getBody().token()),
+                () -> assertEquals(testEmail, response.getBody().email())
         );
         verify(authService, times(1)).login(loginRequest);
     }
@@ -83,11 +93,20 @@ class AuthControllerTest {
     }
 
     @Test
-    void register_Success_ShouldReturnCreatedWithToken() {
-        final URI mockLocation = URI.create("http://mock-location/api/v1/users/12345");
-        when(uriBuilderService.buildUserLocationUri(anyString())).thenReturn(mockLocation);
+    void register_Success_ShouldReturnCreatedWithUserData() {
+        final URI mockLocation = URI.create("http://mock-location/api/v1/users/" + expectedUserId);
+        when(uriBuilderService.buildUserLocationUri(expectedUserId)).thenReturn(mockLocation);
 
-        when(authService.register(any(RegisterRequest.class))).thenReturn(new RegisterResponse("mockJwtToken123"));
+        final RegisterResponse mockServiceResponse = RegisterResponse.builder()
+                .id(expectedUserId)
+                .username(expectedUsername)
+                .email(expectedEmailForRegister)
+                .role(expectedRole)
+                .contactPhone(expectedPhone)
+                .createdAt(mockCreatedAt)
+                .updatedAt(mockUpdatedAt)
+                .build();
+        when(authService.register(any(RegisterRequest.class))).thenReturn(mockServiceResponse);
 
         final ResponseEntity<RegisterResponse> responseEntity = authController.register(registerRequest);
 
@@ -95,10 +114,19 @@ class AuthControllerTest {
                 () -> assertNotNull(responseEntity),
                 () -> assertEquals(HttpStatus.CREATED, responseEntity.getStatusCode()),
                 () -> assertNotNull(responseEntity.getBody()),
-                () -> assertEquals("mockJwtToken123", responseEntity.getBody().getToken())
+                () -> assertEquals(expectedUserId, responseEntity.getBody().getId()),
+                () -> assertEquals(expectedUsername, responseEntity.getBody().getUsername()),
+                () -> assertEquals(expectedEmailForRegister, responseEntity.getBody().getEmail()),
+                () -> assertEquals(expectedRole, responseEntity.getBody().getRole()),
+                () -> assertEquals(expectedPhone, responseEntity.getBody().getContactPhone()),
+                () -> assertEquals(mockCreatedAt, responseEntity.getBody().getCreatedAt()),
+                () -> assertEquals(mockUpdatedAt, responseEntity.getBody().getUpdatedAt()),
+                () -> assertEquals(mockLocation, responseEntity.getHeaders().getLocation())
         );
 
         verify(authService, times(1)).register(registerRequest);
+        verify(uriBuilderService, times(1))
+                .buildUserLocationUri(expectedUserId);
     }
 
     @Test
@@ -114,5 +142,4 @@ class AuthControllerTest {
         assertEquals(expectedException, thrownException);
         verify(authService, times(1)).register(registerRequest);
     }
-
 }

--- a/src/test/java/com/igrowker/feature/parkify/features/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/igrowker/feature/parkify/features/auth/service/AuthServiceImplTest.java
@@ -1,18 +1,22 @@
 package com.igrowker.feature.parkify.features.auth.service;
 
+import com.igrowker.feature.parkify.exception.EmailAlreadyExistsException;
 import com.igrowker.feature.parkify.features.auth.dto.request.RegisterRequest;
 import com.igrowker.feature.parkify.features.auth.dto.response.RegisterResponse;
 import com.igrowker.feature.parkify.features.auth.entities.AuthUser;
+import com.igrowker.feature.parkify.features.auth.entities.Role;
 import com.igrowker.feature.parkify.features.auth.repository.AuthUserRepository;
-import com.igrowker.feature.parkify.features.auth.security.JwtService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.security.core.userdetails.User;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -25,60 +29,147 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+@ExtendWith(MockitoExtension.class)
 class AuthServiceImplTest {
 
     @Mock
-    private JwtService jwtService;
-
-    @Mock
     private AuthUserRepository authUserRepository;
-
     @Mock
     private PasswordEncoder passwordEncoder;
-
     @InjectMocks
     private AuthServiceImpl authService;
 
+    @Captor
+    private ArgumentCaptor<AuthUser> authUserArgumentCaptor;
+
     private RegisterRequest registerRequest;
+    private AuthUser savedAuthUserMock;
 
     @BeforeEach
     void setUp() {
         registerRequest = new RegisterRequest(
-                "NewUser", "newuser@example.com", "123456",
-                "OWNER", "0123456789"
+                "NewUser",
+                "newuser@example.com",
+                "password123",
+                "OWNER",
+                "0123456789"
         );
+        savedAuthUserMock = AuthUser.builder()
+                .id(1L)
+                .email(registerRequest.email())
+                .password("encodedPassword")
+                .role(Role.valueOf(registerRequest.role()))
+                .username(registerRequest.username())
+                .contactPhone(registerRequest.contactPhone())
+                .createdAt(LocalDateTime.now().minusSeconds(1))
+                .updatedAt(LocalDateTime.now())
+                .build();
     }
 
     @Test
-    void register_Success_ShouldReturnRegisterResponse() {
+    void register_Success_ShouldReturnCorrectRegisterResponseData() {
         when(authUserRepository.findByEmail(registerRequest.email()))
                 .thenReturn(Optional.empty());
         when(passwordEncoder.encode(registerRequest.password()))
                 .thenReturn("encodedPassword");
-        when(jwtService.generateToken(any(User.class)))
-                .thenReturn("mocked-jwt-token");
+        when(authUserRepository.save(any(AuthUser.class)))
+                .thenReturn(savedAuthUserMock);
 
         final RegisterResponse response = authService.register(registerRequest);
 
-        assertNotNull(response);
-        assertAll(
-                () -> assertEquals("mocked-jwt-token", response.getToken())
+        assertNotNull(response, "Response should not be null");
+        verify(authUserRepository, times(1)).save(authUserArgumentCaptor.capture());
+        final AuthUser capturedUser = authUserArgumentCaptor.getValue();
+        assertAll("Captured AuthUser to be saved",
+                () -> assertEquals(registerRequest.email(), capturedUser.getEmail()),
+                () -> assertEquals("encodedPassword", capturedUser.getPassword()),
+                () -> assertEquals(Role.valueOf(registerRequest.role()), capturedUser.getRole()),
+                () -> assertEquals(registerRequest.username(), capturedUser.getUsername()),
+                () -> assertEquals(registerRequest.contactPhone(), capturedUser.getContactPhone())
         );
-
-        verify(authUserRepository, times(1)).save(any(AuthUser.class));
+        assertAll("RegisterResponse content",
+                () -> assertEquals(String.valueOf(savedAuthUserMock.getId()), response.getId()),
+                () -> assertEquals(savedAuthUserMock.getUsername(), response.getUsername()),
+                () -> assertEquals(savedAuthUserMock.getEmail(), response.getEmail()),
+                () -> assertEquals(savedAuthUserMock.getRole().name(), response.getRole()),
+                () -> assertEquals(savedAuthUserMock.getContactPhone(), response.getContactPhone()),
+                () -> assertEquals(savedAuthUserMock.getCreatedAt(), response.getCreatedAt()),
+                () -> assertEquals(savedAuthUserMock.getUpdatedAt(), response.getUpdatedAt())
+        );
     }
 
     @Test
-    void register_EmailAlreadyExists_ShouldThrowException() {
+    void register_EmailAlreadyExists_ShouldThrowEmailAlreadyExistsException() {
         when(authUserRepository.findByEmail(registerRequest.email()))
                 .thenReturn(Optional.of(new AuthUser()));
 
-        final RuntimeException exception = assertThrows(RuntimeException.class, () ->
+        final EmailAlreadyExistsException exception = assertThrows(EmailAlreadyExistsException.class, () ->
                 authService.register(registerRequest)
         );
 
-        assertEquals("El correo electrónico ya está registrado.", exception.getMessage());
+        assertEquals("This email already registered.", exception.getMessage());
         verify(authUserRepository, never()).save(any());
+    }
+
+    @Test
+    void register_NullRoleInRequest_ShouldUseDefaultRole() {
+        final RegisterRequest requestWithNullRole = new RegisterRequest(
+                "TestUserNullRole",
+                "nullrole@example.com",
+                "password123",
+                null,
+                "1234567890"
+        );
+        final AuthUser savedUserWithDefaultRole = AuthUser.builder()
+                .id(2L)
+                .email(requestWithNullRole.email())
+                .password("encodedPasswordForNullRole")
+                .role(Role.OWNER)
+                .username(requestWithNullRole.username())
+                .contactPhone(requestWithNullRole.contactPhone())
+                .createdAt(LocalDateTime.now().minusSeconds(1))
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(authUserRepository.findByEmail(requestWithNullRole.email())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(requestWithNullRole.password())).thenReturn("encodedPasswordForNullRole");
+        when(authUserRepository.save(any(AuthUser.class))).thenReturn(savedUserWithDefaultRole);
+
+        authService.register(requestWithNullRole);
+
+        verify(authUserRepository).save(authUserArgumentCaptor.capture());
+        final AuthUser capturedUser = authUserArgumentCaptor.getValue();
+        assertEquals(Role.OWNER, capturedUser.getRole(), "Default role should be OWNER when request role is null");
+    }
+
+    @Test
+    void register_NullUsernameInRequest_ShouldUseEmptyStringForUsername() {
+        final RegisterRequest requestWithNullUsername = new RegisterRequest(
+                null,
+                "nullusername@example.com",
+                "password123",
+                "DRIVER",
+                "1234567890"
+        );
+        final AuthUser savedUserWithEmptyUsername = AuthUser.builder()
+                .id(3L)
+                .email(requestWithNullUsername.email())
+                .password("encodedPasswordForNullUser")
+                .role(Role.DRIVER)
+                .username("")
+                .contactPhone(requestWithNullUsername.contactPhone())
+                .createdAt(LocalDateTime.now().minusSeconds(1))
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(authUserRepository.findByEmail(requestWithNullUsername.email())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(requestWithNullUsername.password())).thenReturn("encodedPasswordForNullUser");
+        when(authUserRepository.save(any(AuthUser.class))).thenReturn(savedUserWithEmptyUsername);
+
+        authService.register(requestWithNullUsername);
+
+        verify(authUserRepository).save(authUserArgumentCaptor.capture());
+        final AuthUser capturedUser = authUserArgumentCaptor.getValue();
+        assertEquals("", capturedUser.getUsername(), "Username should be empty string when request username is null");
     }
 }


### PR DESCRIPTION
…ents

Refactors authentication DTOs and service logic to match the data structure and flow expected by the frontend team.

- Registration endpoint (`/auth/register`) now returns user data (ID, username, email, role, contactPhone, createdAt, updatedAt) instead of a token upon successful user creation (201 Created).
- `UserResponse` DTO now includes `createdAt` and `updatedAt` fields.
- `AuthUser` entity now includes `createdAt` and `updatedAt` fields, managed by Hibernate's @CreationTimestamp and @UpdateTimestamp.
- `RegisterRequest` DTO's `username` field is now visible in Swagger and handled as optional in the service (defaulting to empty string if not provided). Role defaults to OWNER if not provided.
- Unit and Integration tests for AuthController and AuthService have been updated to reflect these changes.

BREAKING CHANGE: The response structure for the POST /api/v1/auth/register endpoint has changed. It no longer returns a JWT token in the main body but returns user profile data. Frontend will need to make a separate login request to obtain a token after successful registration as usual.