### PR TITLE
2 agregar update delate user

### DIFF
--- a/src/main/java/com/igrowker/feature/parkify/features/auth/controller/AuthController.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.igrowker.feature.parkify.exception.GlobalExceptionHandler;
 import com.igrowker.feature.parkify.features.auth.dto.request.LoginRequest;
 import com.igrowker.feature.parkify.features.auth.dto.request.RegisterRequest;
 import com.igrowker.feature.parkify.features.auth.dto.request.UpdateEmailRequest;
+import com.igrowker.feature.parkify.features.auth.dto.request.UpdateUserRequest;
 import com.igrowker.feature.parkify.features.auth.dto.response.LoginResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.RegisterResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.UserResponse;
@@ -191,12 +192,54 @@ public class AuthController {
                 content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                         schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
     })
-    @DeleteMapping("/my")
+    @DeleteMapping("/me")
     public ResponseEntity<Void> deleteMyUser(Authentication authentication) {
         String userEmail  = authentication.getName();
         authService.deleteUser(userEmail);
         return ResponseEntity.noContent().build();
     }
 
-
+    //update User
+    @Operation(
+        summary = "Update user profile",
+        description = "Allows the authenticated user to fully update their profile: username, email, contact phone, location."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+                responseCode = "200",
+                description = "User updated successfully",
+                content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = UserResponse.class)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "Invalid request data",
+                content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "401",
+                description = "Unauthorized"
+        ),
+        @ApiResponse(
+                responseCode = "409",
+                description = "Email already in use",
+                content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)
+                )
+        )
+    })
+    @PutMapping("/me")
+    public ResponseEntity<UserResponse> updateUser(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @Valid @RequestBody UpdateUserRequest request
+    ) {
+        UserResponse updatedUser = authService.updateUser(userDetails.getUsername(), request);
+        return ResponseEntity.ok(updatedUser);
+    }
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/controller/AuthController.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/controller/AuthController.java
@@ -22,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -177,5 +178,25 @@ public class AuthController {
         authService.updateEmail(userDetails.getUsername(), request.newEmail());
         return ResponseEntity.ok().build();
     }
+
+    //delete User
+    @Operation(
+        summary = "Delete User",
+        description = "Allows the authenticated user (OWNER or DRIVER) to delete their own account."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "User deleted successfully"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "404", description = "User not found",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
+    })
+    @DeleteMapping("/my")
+    public ResponseEntity<Void> deleteMyUser(Authentication authentication) {
+        String userEmail  = authentication.getName();
+        authService.deleteUser(userEmail);
+        return ResponseEntity.noContent().build();
+    }
+
 
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/dto/request/UpdateUserRequest.java
@@ -1,0 +1,28 @@
+package com.igrowker.feature.parkify.features.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "Request to update the user's profile information")
+public record UpdateUserRequest (
+
+    @Schema(description = "New username", example = "new_name")
+    @NotBlank(message = "Username cannot be blank")
+    String username,
+
+    @Schema(description = "New email address", example = "test@example.com")
+    @NotBlank(message = "Email cannot be blank")
+    @Email(message = "Invalid email format")
+    String email,
+
+    @Schema(description = "Updated contact phone number", example = "1122334455")
+    @NotBlank(message = "Contact phone cannot be blank")
+    String contactPhone,
+
+    @Schema(description = "New latitude for the user location", example = "-34.6037")
+    Double latitude,
+
+    @Schema(description = "New longitude for the user location", example = "-58.3816")
+    Double longitude
+) {}

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/security/SecurityConfig.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/security/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 antMatcher(HttpMethod.GET, AUTH_PATH + "/me"),
                                 antMatcher(HttpMethod.PUT, USERS_PATH + "/me/location"),
+                                antMatcher(HttpMethod.DELETE, USERS_PATH + "/my"),
                                 antMatcher(HttpMethod.GET, RECOMMENDATIONS_PATH + "/zones"),
                                 antMatcher(HttpMethod.GET, RECOMMENDATIONS_PATH + "/parkings"),
                                 antMatcher(HttpMethod.PATCH, BOOKINGS_PATH + "/{bookingRequestId}"),

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/security/SecurityConfig.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/security/SecurityConfig.java
@@ -62,7 +62,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 antMatcher(HttpMethod.GET, AUTH_PATH + "/me"),
                                 antMatcher(HttpMethod.PUT, USERS_PATH + "/me/location"),
-                                antMatcher(HttpMethod.DELETE, USERS_PATH + "/my"),
+                                antMatcher(HttpMethod.DELETE, USERS_PATH + "/me"),
+                                antMatcher(HttpMethod.PUT, AUTH_PATH + "/me"),
                                 antMatcher(HttpMethod.GET, RECOMMENDATIONS_PATH + "/zones"),
                                 antMatcher(HttpMethod.GET, RECOMMENDATIONS_PATH + "/parkings"),
                                 antMatcher(HttpMethod.PATCH, BOOKINGS_PATH + "/{bookingRequestId}"),

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthService.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthService.java
@@ -4,6 +4,7 @@ package com.igrowker.feature.parkify.features.auth.service;
 import com.igrowker.feature.parkify.features.auth.dto.request.LoginRequest;
 import com.igrowker.feature.parkify.features.auth.dto.request.RegisterRequest;
 import com.igrowker.feature.parkify.features.auth.dto.request.UpdateEmailRequest;
+import com.igrowker.feature.parkify.features.auth.dto.request.UpdateUserRequest;
 import com.igrowker.feature.parkify.features.auth.dto.response.LoginResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.RegisterResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.UserResponse;
@@ -14,4 +15,5 @@ public interface AuthService {
     UserResponse getCurrentUserDetails(String email);
     void updateEmail(String currentEmail, String newEmail);
     void deleteUser(String email);
+    UserResponse updateUser(String currentEmail, UpdateUserRequest request);
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthService.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthService.java
@@ -13,5 +13,5 @@ public interface AuthService {
     RegisterResponse register(RegisterRequest request);
     UserResponse getCurrentUserDetails(String email);
     void updateEmail(String currentEmail, String newEmail);
-
+    void deleteUser(String email);
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthServiceImpl.java
@@ -11,6 +11,8 @@ import com.igrowker.feature.parkify.features.auth.entities.Role;
 import com.igrowker.feature.parkify.features.auth.repository.AuthUserRepository;
 import com.igrowker.feature.parkify.features.auth.security.JwtService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -19,6 +21,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
@@ -99,6 +102,16 @@ public class AuthServiceImpl implements AuthService {
 
         user.setEmail(newEmail);
         authUserRepository.save(user);
+    }
+
+    //delete user
+    @Override
+    @Transactional
+    public void deleteUser(String email) {
+        log.info("Deleting user with email: {}", email);
+        AuthUser user = authUserRepository.findByEmail(email)
+            .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+        authUserRepository.delete(user);
     }
 
 }

--- a/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/igrowker/feature/parkify/features/auth/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package com.igrowker.feature.parkify.features.auth.service;
 import com.igrowker.feature.parkify.exception.EmailAlreadyExistsException;
 import com.igrowker.feature.parkify.features.auth.dto.request.LoginRequest;
 import com.igrowker.feature.parkify.features.auth.dto.request.RegisterRequest;
+import com.igrowker.feature.parkify.features.auth.dto.request.UpdateUserRequest;
 import com.igrowker.feature.parkify.features.auth.dto.response.LoginResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.RegisterResponse;
 import com.igrowker.feature.parkify.features.auth.dto.response.UserResponse;
@@ -112,6 +113,41 @@ public class AuthServiceImpl implements AuthService {
         AuthUser user = authUserRepository.findByEmail(email)
             .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
         authUserRepository.delete(user);
+    }
+
+    //update user
+    @Override
+    @Transactional
+    public UserResponse updateUser(String currentEmail, UpdateUserRequest request) {
+        AuthUser user = authUserRepository.findByEmail(currentEmail)
+            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        if (!currentEmail.equals(request.email()) &&
+            authUserRepository.findByEmail(request.email()).isPresent()) {
+            throw new EmailAlreadyExistsException("Email already in use");
+        }
+
+        user.setUsername(request.username());
+        user.setEmail(request.email());
+        user.setContactPhone(request.contactPhone());
+        if(request.latitude() != null) {
+            user.setLatitude(request.latitude());
+        }
+        if(request.longitude() != null){
+            user.setLongitude(request.longitude());
+        }
+
+        AuthUser saved = authUserRepository.save(user);
+
+        return UserResponse.builder()
+                .id(String.valueOf(saved.getId()))
+                .username(saved.getUsername())
+                .email(saved.getEmail())
+                .role(saved.getRole().name())
+                .contactPhone(saved.getContactPhone())
+                .createdAt(saved.getCreatedAt())
+                .updatedAt(saved.getUpdatedAt())
+                .build();
     }
 
 }


### PR DESCRIPTION
Descripción
Se agregan dos nuevos endpoints relacionados con la gestión del perfil del usuario autenticado (OWNER o DRIVER):

✅ PUT /api/v1/auth/me
Permite al usuario autenticado actualizar completamente su perfil.
Campos modificables:
username
email
contactPhone
latitude
longitude

El endpoint valida que el nuevo email no esté en uso por otro usuario y devuelve un objeto UserResponse con los datos actualizados.

 DELETE /api/v1/auth/me
Permite al usuario autenticado eliminar su propia cuenta de manera segura.
No requiere body, solo un token JWT válido en el header Authorization.

Ambos endpoints están protegidos por autenticación y requieren rol OWNER o DRIVER.